### PR TITLE
Delete desktop.ini

### DIFF
--- a/AIDS_AI_upscaled/desktop.ini
+++ b/AIDS_AI_upscaled/desktop.ini
@@ -1,2 +1,0 @@
-[.ShellClassInfo]
-LocalizedResourceName=@AIDS_AI_upscaled,0


### PR DESCRIPTION
This is a file Windows' Explorer will make. I assume it was only added by mistake.